### PR TITLE
Amended some incorrect assumptions, refactored project set calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 A simple reimbursement calculator algorithm.
 
 ### Running the project
+TL;DR
+```
+ruby main.rb
+# or if you prefer docker
+docker compose run release
+```
+
 This project can be run from any ruby 3.4.1 (untested in other versions) development environment. Simply run:
 `ruby main.rb`
 from the project root.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# These services are not meant to be run simultaneously.
+# The dev service is intented for local development, the release service is intented for production
 services:
   dev:
     build:

--- a/main.rb
+++ b/main.rb
@@ -1,4 +1,10 @@
 require 'json'
+require_relative './src/project_set'
 
 json = JSON.parse(File.read('input.json'))
-puts json
+json['sets'].each do |json_set|
+
+  project_set = ProjectSet.from_hash(json_set)
+  total_reimbursement = project_set.calculate_total_reimbursement
+  puts "#{project_set.name} reimbursement: $#{total_reimbursement}.00"
+end

--- a/src/project.rb
+++ b/src/project.rb
@@ -23,15 +23,18 @@ class Project
     @duration = calculate_duration
   end
 
+  def each_date(&block)
+    duration.times do |date_offest|
+      block.call(start_date + date_offest)
+    end
+  end
+
   def contains_date?(date)
     start_date <= date && end_date >= date
   end
 
   def is_full_day?(date)
     return false unless contains_date?(date)
-
-    # If the duration of the project is only one day, then that day is a full day
-    return true if duration == 1
 
     date != start_date && date != end_date
   end
@@ -47,7 +50,7 @@ class Project
 
   # This method is used to calculate the rate for a single project on a given day.
   # NOTE: This method does not attempt to return the final rate for a project in the context of a set.
-  # See ProjectSet#calculate_total_cost for the logic used to calculate project set total
+  # See ProjectSet#calculate_total_reimbursement for the logic used to calculate project set total
   def solo_rate(date)
     if is_full_day?(date)
       is_high_cost_city? ? HIGH_COST_CITY_FULL_DAY_RATE : LOW_COST_CITY_FULL_DAY_RATE

--- a/tests/project_set_tests.rb
+++ b/tests/project_set_tests.rb
@@ -7,17 +7,18 @@ ts = TestSuite.new
 ts.test "ProjectSet can calculate total cost for a single project correctly" do
   proj = Project.new(start_date: '9/1/2025', end_date: '9/3/2025', city_type: 'High Cost City')
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj])
-  proj_set.calculate_total_cost == 235
+
+  proj_set.calculate_total_reimbursement == 235
 end
 
 ts.test "ProjectSet can calculate total cost for single day projects correctly" do
   proj = Project.new(start_date: '9/1/2025', end_date: '9/1/2025', city_type: 'High Cost City')
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj])
-  proj_set.calculate_total_cost == 85
+  proj_set.calculate_total_reimbursement == 75
 end
 
 ts.test "ProjectSet can calculate total cost for multiple projects correctly" do
-  # Estimated value: 55
+  # Estimated value: 45
   proj1 = Project.new(start_date: '9/1/2025', end_date: '9/1/2025', city_type: 'Low Cost City')
 
   # Estimated value: 75 + 85 + 75 = 235
@@ -27,7 +28,7 @@ ts.test "ProjectSet can calculate total cost for multiple projects correctly" do
   proj3 = Project.new(start_date: '9/7/2025', end_date: '9/12/2025', city_type: 'Low Cost City')
 
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj1, proj2, proj3])
-  proj_set.calculate_total_cost == 600
+  proj_set.calculate_total_reimbursement == 590
 end
 
 ts.test "ProjectSet accounts for date neighbors when calculating cost" do
@@ -41,7 +42,7 @@ ts.test "ProjectSet accounts for date neighbors when calculating cost" do
   proj3 = Project.new(start_date: '9/6/2025', end_date: '9/7/2025', city_type: 'Low Cost City')
 
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj1, proj2, proj3])
-  proj_set.calculate_total_cost == 495
+  proj_set.calculate_total_reimbursement == 495
 end
 
 ts.test "ProjectSet accounts for project overlaps when calculating cost" do
@@ -55,13 +56,13 @@ ts.test "ProjectSet accounts for project overlaps when calculating cost" do
   proj3 = Project.new(start_date: '9/5/2025', end_date: '9/7/2025', city_type: 'Low Cost City')
 
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj1, proj2, proj3])
-  proj_set.calculate_total_cost == 495
+  proj_set.calculate_total_reimbursement == 495
 end
 
 ts.test "reimbursements can be correctly calculated from input.json" do
   json = JSON.parse(File.read('./input.json'))
   totals = json['sets'].map do |json_set|
-    ProjectSet.from_hash(json_set).calculate_total_cost
+    ProjectSet.from_hash(json_set).calculate_total_reimbursement
   end
   totals == [145, 580, 475, 225]
 end

--- a/tests/project_tests.rb
+++ b/tests/project_tests.rb
@@ -28,6 +28,15 @@ ts.test "Project contains_date? can correctly determine if a date is within the 
   )
 end
 
+ts.test "Project each_date correctly iterates over all dates in the project" do
+  proj = Project.new(start_date: '9/1/2025', end_date: '9/3/2025', city_type: 'High Cost City')
+  dates = []
+  proj.each_date do |date|
+    dates << date.strftime('%m/%d/%Y')
+  end
+  dates == ['09/01/2025', '09/02/2025', '09/03/2025']
+end
+
 ts.test "Project is_full_day? can correctly determine if a date is a full day" do
   proj = Project.new(start_date: '9/1/2025', end_date: '9/3/2025', city_type: 'High Cost City')
   (


### PR DESCRIPTION
In addition to renaming and general refactoring, I've opted for a more performant approach to reimbursement calculation.

Using a lookup hash for referencing projects and storing project references in an array corresponding to the dates cuts down on unnecessary looping.

Logic has also been adjusted to no longer count single-day-duration projects as full days (assuming no neighbors or overlaps).

README has also been updated to be a little less wordy, and the main "executable" now actually does something.