### PR TITLE
Updated README, modified project set start and end date rate logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ TL;DR
 ruby main.rb
 # or if you prefer docker
 docker compose run release
+
+# Output of executable:
+Set 1 reimbursement: $145.00
+Set 2 reimbursement: $570.00
+Set 3 reimbursement: $465.00
+Set 4 reimbursement: $205.00
 ```
 
 This project can be run from any ruby 3.4.1 (untested in other versions) development environment. Simply run:
@@ -51,4 +57,44 @@ SamCorp has requested some simple software to calculate reimbursement based on s
 - Projects will be given as JSON (see input.json for format)
 - All cities will be either "High Cost City" or "Low Cost City"
 - When 2 projects in different city types occur on the same day, we will use the High Cost City rate
-- Single day duration projects will use the full day rate
+- Single day duration projects will use the travel day rate
+- Overlapping project dates will use the more expensive rate of the overlapping projects.
+- Projects that are date nieghbors (start / end within one day) will have the neighboring dates calculated as full days.
+
+### Sample Calculations
+In order to help clarify these rules and assumptions, here are the calculations for 2 examples.
+Note: Each column is a date, numbered 1 .. final day in the set. The x's in each row correspond with the date that the project in that row is active.
+
+```
+Set 3 from input.json
+
+          Dates
+Project   1  2  3  4  5  6  7  8
+Low Cost  x  x  x
+High Cost             x  x  x
+High Cost                      x
+```
+
+Date 1: The first date of the set, this is a Low Cost travel date.
+Date 2: Day in the middle of a project, Low Cost full date.
+Date 3: Last day of a project, Low Cost tavel date.
+Date 4: No projects.
+Date 5: First day of a project, High Cost travel date.
+Date 6: Day in the middle of a project, High Cost full date.
+Date 7: Last day of the project, however it neighbors the next project, therefore it is a High Cost full date.
+Date 8: Even those this neighbors another project, it is the last date in the set, and is therefore a tavel date.
+
+```
+Set 4 from input.json
+
+          Dates
+Project   1  2  3
+Low Cost  x
+Low Cost  x
+High Cost    x
+High Cost    x  x
+```
+
+Date 1: Although this project both overlaps and is neighbors with sibling projects, it is the first date in the set, and therefore a travel day. We will use the Low Cost rate because it overlaps with another Low Cost project.
+Date 2: Although this is the first date for project 3, it is both a neighbor and an overlapping date with projects 2 and 4. Project 4 is High Cost and overlapping, therefore we will use the High Cost full date rate.
+Date 3: This is the last date in the set, so even though it is neighbors with project 3, it will be counted as a High Cost full day.

--- a/tests/project_set_tests.rb
+++ b/tests/project_set_tests.rb
@@ -32,7 +32,7 @@ ts.test "ProjectSet can calculate total cost for multiple projects correctly" do
 end
 
 ts.test "ProjectSet accounts for date neighbors when calculating cost" do
-  # Estimated value: 55
+  # Estimated value: 45
   proj1 = Project.new(start_date: '9/1/2025', end_date: '9/1/2025', city_type: 'Low Cost City')
 
   # Estimated value: 85 + 85 + 85 + 85 = 340
@@ -42,11 +42,11 @@ ts.test "ProjectSet accounts for date neighbors when calculating cost" do
   proj3 = Project.new(start_date: '9/6/2025', end_date: '9/7/2025', city_type: 'Low Cost City')
 
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj1, proj2, proj3])
-  proj_set.calculate_total_reimbursement == 495
+  proj_set.calculate_total_reimbursement == 485
 end
 
 ts.test "ProjectSet accounts for project overlaps when calculating cost" do
-  # Estimated value: 55
+  # Estimated value: 45
   proj1 = Project.new(start_date: '9/1/2025', end_date: '9/3/2025', city_type: 'Low Cost City')
 
   # Estimated value: 85 + 85 + 85 + 85 = 340
@@ -56,7 +56,7 @@ ts.test "ProjectSet accounts for project overlaps when calculating cost" do
   proj3 = Project.new(start_date: '9/5/2025', end_date: '9/7/2025', city_type: 'Low Cost City')
 
   proj_set = ProjectSet.new(name: 'Test Project Set', projects: [proj1, proj2, proj3])
-  proj_set.calculate_total_reimbursement == 495
+  proj_set.calculate_total_reimbursement == 485
 end
 
 ts.test "reimbursements can be correctly calculated from input.json" do
@@ -64,7 +64,7 @@ ts.test "reimbursements can be correctly calculated from input.json" do
   totals = json['sets'].map do |json_set|
     ProjectSet.from_hash(json_set).calculate_total_reimbursement
   end
-  totals == [145, 580, 475, 225]
+  totals == [145, 570, 465, 205]
 end
 
 ts.run


### PR DESCRIPTION
The README now has a visualization to help understand the logic behind the rate calculations.
I've also added the program output so curious watchers don't need to run the code locally.

The logic surrounding travel days has changed slightly so that the first and last days of a project set are forced to be travel days, regardless of overlaps or neighbors.
Tests have been updated to reflect this change.